### PR TITLE
Don't check/fix files during a merge commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# If currently in a merge don't check files.
+MERGE=$(git rev-parse -q --verify MERGE_HEAD)
+if [[ ! -z "$MERGE" ]]
+then
+  # Currently in merge, let git handle the rest.
+  exit 0
+fi
+
 # Get list of staged files excluding deleted files (lowercase d in --diff-filter).
 FILES=$(git diff --cached --name-only --diff-filter=d | grep \\.php)
 if [[ $(echo $FILES | wc -c) -eq "1" ]]


### PR DESCRIPTION
Even though we can use '--no-verify' to not run the pre-commit, in the case of merges we might want to do it automatically to avoid large amounts of fixes in the case of large merges.

This change checks if git is currently in a merge process via MERGE_HEAD and does not run the rest of the pre-commit hook if git's in a merge.